### PR TITLE
bugfix: 修复u-radio文档中对label-disabled属性取值描述错误的问题

### DIFF
--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -112,7 +112,7 @@ export default {
 
 ### 文本是否可点击
 
-设置`label-disabled`为`false`，点击文本时，无法操作`radio`
+设置`label-disabled`为`true`，点击文本时，无法操作`radio`
 
 
 ```html


### PR DESCRIPTION
文本是否可点击
应该是设置label-disabled为true，点击文本时，无法操作radio
而不是设置label-disabled为false，点击文本时，无法操作radio